### PR TITLE
Convert MJML to HTML in a background thread

### DIFF
--- a/newsletterist/pages/index.tsx
+++ b/newsletterist/pages/index.tsx
@@ -1,5 +1,4 @@
 import { NextPage, GetStaticProps } from "next";
-import { markdownToMJML, renderMJML } from "src/mjml";
 import { readFileSync } from "fs";
 import { join, resolve } from "path";
 import Newsletterist from "src/newsletterist";
@@ -9,17 +8,8 @@ interface Props {
 }
 
 const Home: NextPage<Props> = ({ contentStyles }) => {
-  const markdownToMjml = (markdown: string) =>
-    renderMJML(markdownToMJML(markdown, contentStyles));
-  return (
-    <Newsletterist markdownToMjml={markdownToMjml} mjmlToHtml={mjmlToHtml} />
-  );
+  return <Newsletterist contentStyles={contentStyles} />;
 };
-
-async function mjmlToHtml(mjml: string): Promise<string> {
-  const response = await fetch("/api/mjml", { method: "POST", body: mjml });
-  return response.ok ? await response.text() : "MJML conversion failed :(";
-}
 
 export const getStaticProps: GetStaticProps<Props> = async () => {
   const stylePath = join(resolve(process.cwd()), "src/content.css");

--- a/newsletterist/src/newsletterist.tsx
+++ b/newsletterist/src/newsletterist.tsx
@@ -1,24 +1,39 @@
 import Editor from "src/editor";
 import Preview from "src/preview";
-import { useEffect, useState } from "react";
+import { markdownToMJML, renderMJML } from "src/mjml";
+import { useEffect, useRef, useState } from "react";
 
 interface Props {
-  markdownToMjml: (markdown: string) => string;
-  mjmlToHtml: (mjml: string) => Promise<string>;
+  contentStyles?: string;
 }
 
-const Newsletterist: React.FC<Props> = ({ mjmlToHtml, markdownToMjml }) => {
+const Newsletterist: React.FC<Props> = ({ contentStyles }) => {
   const [markdown, setMarkdown] = useState("");
   const [mjml, setMjml] = useState("");
   const [html, setHtml] = useState("");
 
+  // Since converting MJML to HTML has to be done through an API, it’s quite slow
+  // and we can’t do it on the UI thread as it would get blocked and jerky. Here we
+  // spawn a web worker to do the conversion in a background thread.
+  const workerRef = useRef<Worker>();
   useEffect(() => {
-    setMjml(markdownToMjml(markdown));
-  }, [markdown, markdownToMjml]);
+    workerRef.current = new Worker(new URL("worker.js", import.meta.url));
+    workerRef.current.onmessage = (event) => setHtml(event.data);
+    // Don’t forger to clean up the worker when the component disappears
+    return () => {
+      workerRef.current?.terminate();
+    };
+  }, []);
 
   useEffect(() => {
-    mjmlToHtml(mjml).then(setHtml);
-  }, [mjml, mjmlToHtml]);
+    const markdownToMjml = (markdown: string) =>
+      renderMJML(markdownToMJML(markdown, contentStyles));
+    setMjml(markdownToMjml(markdown));
+  }, [markdown, contentStyles]);
+
+  useEffect(() => {
+    workerRef.current?.postMessage(mjml);
+  }, [mjml]);
 
   return (
     <div>

--- a/newsletterist/src/worker.js
+++ b/newsletterist/src/worker.js
@@ -1,0 +1,10 @@
+self.onmessage = function (e) {
+  const mjml = e.data;
+  mjmlToHtml(mjml);
+};
+
+function mjmlToHtml(mjml) {
+  fetch("/api/mjml", { method: "POST", body: mjml })
+    .then((response) => response.text())
+    .then((html) => self.postMessage(html));
+}


### PR DESCRIPTION
Povedlo se mně přehodit konverzi MJML do HTML do web workeru, takže už neblokujeme UI thread. Zase to trochu zamotalo kód příslušné komponenty, bylo by lepší vytáhnout I/O někam ven, ale to teď nehoří.