### PR TITLE
Konfigurace pro instalaci Faktory a Nginx pomocí Terraform

### DIFF
--- a/infrastructure/faktory/.gitignore
+++ b/infrastructure/faktory/.gitignore
@@ -1,0 +1,9 @@
+tmp/
+
+demo/cert/
+demo/**/Gemfile.lock
+demo/**/package-lock.json
+demo/**/node_modules
+
+terraform/.terraform*
+terraform/*.tfstate*

--- a/infrastructure/faktory/demo/Gemfile
+++ b/infrastructure/faktory/demo/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem 'faktory_worker_ruby'

--- a/infrastructure/faktory/demo/README.md
+++ b/infrastructure/faktory/demo/README.md
@@ -1,0 +1,21 @@
+# Demo for Faktory background jobs infrastructure
+
+1. Generate the certificates:
+
+```
+mkdir cert
+docker run -it --rm -v $PWD/cert:/cert -w /cert alpine/openssl req -x509 -out /cert/localhost.crt -keyout /cert/localhost.key -newkey rsa:2048 -nodes -sha256 -subj '/CN=localhost'
+```
+
+2. Launch Faktory and Nginx:
+
+```
+FAKTORY_PASSWORD=secret docker-compose up
+```
+
+3. Run the demonstration script:
+
+```
+bundle install
+SSL_CERT_FILE=cert/localhost.crt FAKTORY_PROVIDER=FAKTORY_URL FAKTORY_URL=tcp+tls://:secret@localhost:7491 bundle exec faktory-worker -r ./app.rb
+```

--- a/infrastructure/faktory/demo/app.rb
+++ b/infrastructure/faktory/demo/app.rb
@@ -1,0 +1,24 @@
+# SSL_CERT_FILE=cert/localhost.crt FAKTORY_PROVIDER=FAKTORY_URL FAKTORY_URL=tcp+tls://:secret@localhost:7491 bundle exec faktory-worker -r ./app.rb
+
+require 'connection_pool'
+require 'faktory'
+require 'securerandom'
+
+num_jobs = (ENV['COUNT'] || 10).to_i
+
+class DemoWorker
+  include Faktory::Job
+
+  def perform(*args)
+    puts "sum: #{args.join('+')}=#{args.sum}"
+    sleep 0.5
+  end
+end
+
+Thread.new do
+  while true do
+    puts "==> Pushing #{num_jobs} new jobs to queue..."
+    num_jobs.times { DemoWorker.perform_async(rand(1..25), rand(1..15), rand(1..25)) }
+    sleep 10
+  end
+end

--- a/infrastructure/faktory/demo/docker-compose.yml
+++ b/infrastructure/faktory/demo/docker-compose.yml
@@ -1,0 +1,45 @@
+# FAKTORY_PASSWORD=secret docker-compose up
+#
+# curl --cacert cert/localhost.crt https://:secret@localhost:443/stats
+#
+
+version: "3.8"
+
+services:
+  faktory:
+    image: contribsys/faktory
+    container_name: faktory
+    networks:
+      - faktory
+    environment:
+      - FAKTORY_PASSWORD=${FAKTORY_PASSWORD}
+    volumes:
+      - faktory-data:/var/lib/faktory
+    command: /faktory -b :7419 -w :7420 -e production
+
+  nginx:
+    image: nginx:alpine
+    container_name: nginx
+    depends_on: ['faktory']
+    secrets:
+      - source: nginx.conf
+        target: /etc/nginx/nginx.conf
+    volumes:
+      - ./cert:/etc/nginx/certificates/
+    networks:
+      - faktory
+    ports:
+      - 7491:7491
+      - 443:443
+    healthcheck:
+      test: nginx -t
+
+networks:
+  faktory: { name: faktory-demo }
+
+volumes:
+  faktory-data: { name: faktory-demo-data }
+
+secrets:
+  nginx.conf:
+    file: ./nginx.conf

--- a/infrastructure/faktory/demo/nginx.conf
+++ b/infrastructure/faktory/demo/nginx.conf
@@ -1,0 +1,48 @@
+events {
+  worker_connections  1024;
+}
+
+stream {
+  resolver 127.0.0.11;
+
+  upstream faktory {
+    server faktory:7419;
+  }
+
+  server {
+    listen     7491 ssl;
+    proxy_pass faktory;
+
+    ssl_certificate      /etc/nginx/certificates/localhost.crt;
+    ssl_certificate_key  /etc/nginx/certificates/localhost.key;
+  }
+}
+
+http {
+  resolver 127.0.0.11;
+
+  upstream faktory_web {
+    server faktory:7420;
+  }
+
+  server {
+    listen 443 ssl;
+
+    server_name localhost faktory-web.local;
+
+    ssl_certificate      /etc/nginx/certificates/localhost.crt;
+    ssl_certificate_key  /etc/nginx/certificates/localhost.key;
+
+    default_type text/plain;
+
+    location / {
+      proxy_pass http://faktory_web;
+
+      proxy_set_header Host            $host;
+      proxy_set_header X-Real-IP       $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+      proxy_connect_timeout 1s;
+    }
+  }
+}

--- a/infrastructure/faktory/demo/package.json
+++ b/infrastructure/faktory/demo/package.json
@@ -1,0 +1,7 @@
+{
+  "private": true,
+  "name": "faktory-demo",
+  "dependencies": {
+    "faktory-worker": "^4.2"
+  }
+}

--- a/infrastructure/faktory/demo/push.js
+++ b/infrastructure/faktory/demo/push.js
@@ -1,0 +1,8 @@
+const faktory = require("faktory-worker");
+require('tls');
+
+(async () => {
+  const client = await faktory.connect();
+  await client.job("Example", { foo: "bar" }).push();
+  await client.close(); // reuse client if possible! remember to disconnect!
+})().catch((e) => console.error(e));

--- a/infrastructure/faktory/terraform/.gitignore
+++ b/infrastructure/faktory/terraform/.gitignore
@@ -1,0 +1,2 @@
+.terraform/
+*.tfstate*

--- a/infrastructure/faktory/terraform/README.md
+++ b/infrastructure/faktory/terraform/README.md
@@ -1,0 +1,95 @@
+# Infrastructure for running Faktory
+
+The code in this folder is used to provision infrastructure for
+the background queue system [`contribsys/faktory`](https://github.com/contribsys/faktory)
+with [_Terraform_](https://www.terraform.io).
+
+It expects the following prerequisites:
+
+1. A project within [Google Cloud Platform](https://cloud.google.com) (GCP)
+called `cesko-digital-faktory`.
+
+2. An existing [service account](https://cloud.google.com/iam/docs/service-accounts)
+with the following permissions: `Service Account User`, `Compute Admin`, `Storage Object Admin`.
+
+3. A cloud storage bucket called `terraform-cesko-digital-faktory` with two folders:
+    * `assets/`, which contains a `letsencrypt.tar.gz` file with SSL certificates,
+    * `tf-state/`, which is used by Terraform to manage and synchronize state.
+
+4. A hosted zone `ceskodigital.net` within [Amazon Web Services](https://aws.amazon.com) (AWS)
+for accessing the service.
+
+## Deployment
+
+To create the infrastructure, first export the required environment variables.
+
+The password for accessing Faktory (both the service and web UI:
+
+```
+export TF_VAR_faktory_password=secret
+```
+
+The path to file containing the GCP service account key:
+
+```
+export GOOGLE_APPLICATION_CREDENTIALS=path/to/service-account.json
+```
+
+The AWS credentials:
+
+```
+export AWS_ACCESS_KEY_ID=ABC123
+export AWS_SECRET_ACCESS_KEY=456def
+```
+
+Then, setup and initialize Terraform:
+
+```
+terraform init
+```
+
+Preview planned changes:
+
+```
+terraform plan
+```
+
+Create the infrastructure:
+
+```
+terraform apply
+```
+
+## Troubleshooting
+
+In case the provisioning process fails, and you need to login into the instance,
+use the [`gcloud`](https://cloud.google.com/sdk/docs/install) command line utility.
+
+After installation, authenticate to the `cesko.digital` organization and select
+the `cesko-digital-faktory` project:
+
+```
+gcloud auth login
+gcloud config set project cesko-digital-faktory
+```
+
+To log into the instance over SSH, run:
+
+```
+gcloud compute ssh --zone "europe-west1-b" "faktory"  --project "cesko-digital-faktory"
+```
+
+To inspect the log output of the startup script, run:
+
+```
+sudo journalctl -u google-startup-scripts.service
+```
+
+To inspect the state of the services, use the `docker ps`, `docker logs`, etc. commands.
+
+NOTE: Before executing `docker` commands as an unpriviledged user, run:
+
+```
+sudo usermod -aG docker $USER
+newgrp docker
+```

--- a/infrastructure/faktory/terraform/config/nginx.conf
+++ b/infrastructure/faktory/terraform/config/nginx.conf
@@ -1,0 +1,48 @@
+events {
+  worker_connections  1024;
+}
+
+stream {
+  resolver 127.0.0.11;
+
+  upstream faktory {
+    server faktory:7419;
+  }
+
+  server {
+    listen     7491 ssl;
+    proxy_pass faktory;
+
+    ssl_certificate      /etc/letsencrypt/live/faktory.ceskodigital.net/fullchain.pem;
+    ssl_certificate_key  /etc/letsencrypt/live/faktory.ceskodigital.net/privkey.pem;
+  }
+}
+
+http {
+  resolver 127.0.0.11;
+
+  upstream faktory_web {
+    server faktory:7420;
+  }
+
+  server {
+    listen 443 ssl;
+
+    server_name faktory.ceskodigital.net;
+
+    ssl_certificate      /etc/letsencrypt/live/faktory.ceskodigital.net/fullchain.pem;
+    ssl_certificate_key  /etc/letsencrypt/live/faktory.ceskodigital.net/privkey.pem;
+
+    default_type text/plain;
+
+    location / {
+      proxy_pass http://faktory_web;
+
+      proxy_set_header Host            $host;
+      proxy_set_header X-Real-IP       $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+      proxy_connect_timeout 1s;
+    }
+  }
+}

--- a/infrastructure/faktory/terraform/main.tf
+++ b/infrastructure/faktory/terraform/main.tf
@@ -1,0 +1,145 @@
+terraform {
+  required_version = ">= 1.1"
+
+  backend "gcs" {
+    bucket = "terraform-cesko-digital-faktory"
+    prefix = "tf-state"
+  }
+}
+
+provider "google" {
+  project = "cesko-digital-faktory"
+  region  = var.instance_region
+}
+
+provider "aws" {}
+
+resource "google_compute_network" "faktory" {
+  name                    = "faktory-vpc"
+  description             = "Network for Faktory"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "faktory" {
+  name          = "faktory-subnet"
+  ip_cidr_range = "10.0.0.0/22"
+  region        = var.instance_region
+  network       = google_compute_network.faktory.self_link
+}
+
+resource "google_compute_firewall" "allow-ssh" {
+  name        = "${google_compute_network.faktory.name}-allow-ssh"
+  description = "Allow SSH from external"
+  network     = google_compute_network.faktory.self_link
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["allow-ssh"]
+}
+
+# Note: HTTP is needed for the Certbot standalone server
+resource "google_compute_firewall" "allow-http" {
+  name        = "${google_compute_network.faktory.name}-allow-http"
+  description = "Allow HTTP from external"
+  network     = google_compute_network.faktory.self_link
+
+  allow {
+    protocol = "tcp"
+    ports    = ["443"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["allow-http"]
+}
+
+resource "google_compute_firewall" "allow-https" {
+  name        = "${google_compute_network.faktory.name}-allow-https"
+  description = "Allow HTTPS from external"
+  network     = google_compute_network.faktory.self_link
+
+  allow {
+    protocol = "tcp"
+    ports    = ["443"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["allow-https"]
+}
+
+resource "google_compute_firewall" "allow-faktory" {
+  name        = "${google_compute_network.faktory.name}-allow-faktory"
+  description = "Allow Faktory from external"
+  network     = google_compute_network.faktory.self_link
+
+  allow {
+    protocol = "tcp"
+    ports    = ["7491"]
+  }
+
+  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["allow-faktory"]
+}
+
+resource "google_compute_disk" "faktory" {
+  name = "faktory-data"
+  type = "pd-ssd"
+  zone = "${var.instance_region}-b"
+  size = 25
+  # snapshot = "snapshot-1"
+  labels = { group = "faktory" }
+}
+
+resource "google_compute_instance" "faktory" {
+  name         = "faktory"
+  description  = "Faktory running behind Nginx"
+  zone         = "${var.instance_region}-b"
+  machine_type = var.instance_type
+
+  boot_disk {
+    initialize_params {
+      image = var.instance_image
+    }
+  }
+
+  attached_disk {
+    source      = google_compute_disk.faktory.self_link
+    device_name = google_compute_disk.faktory.name
+    mode        = "READ_WRITE"
+  }
+
+  network_interface {
+    network    = google_compute_network.faktory.self_link
+    subnetwork = google_compute_subnetwork.faktory.self_link
+    access_config {}
+  }
+
+  service_account {
+    scopes = ["storage-ro"]
+  }
+
+  tags   = ["allow-ssh", "allow-https", "allow-faktory"]
+  labels = { group = "faktory" }
+
+  metadata_startup_script = templatefile(
+    "${path.module}/scripts/startup.sh.tmpl", {
+      disk_id : "google-${google_compute_disk.faktory.name}",
+      mount_path : "/data",
+      nginx_config : file("${path.module}/config/nginx.conf"),
+      bucket_name : var.assets_bucket_name,
+      faktory_password : var.faktory_password
+    }
+  )
+}
+
+resource "aws_route53_record" "faktory" {
+  zone_id         = var.aws_zone_id
+  name            = "faktory.ceskodigital.net"
+  type            = "A"
+  ttl             = "60"
+  records         = [google_compute_instance.faktory.network_interface.0.access_config.0.nat_ip]
+  allow_overwrite = true
+}

--- a/infrastructure/faktory/terraform/outputs.tf
+++ b/infrastructure/faktory/terraform/outputs.tf
@@ -1,0 +1,7 @@
+output "instance_name" {
+  value = google_compute_instance.faktory.name
+}
+
+output "instance_public_ip" {
+  value = google_compute_instance.faktory.network_interface.0.access_config.0.nat_ip
+}

--- a/infrastructure/faktory/terraform/scripts/startup.sh.tmpl
+++ b/infrastructure/faktory/terraform/scripts/startup.sh.tmpl
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+
+sudo su -
+
+# ----- Mount the attached disk
+echo "=> Mounting the attached disk"
+DEVICE_PATH=$(realpath /dev/disk/by-id/${disk_id})
+MNT_DIR=${mount_path}
+
+echo "   DEVICE_PATH: $DEVICE_PATH"
+echo "   MNT_DIR:     $MNT_DIR"
+
+if blkid $DEVICE_PATH; then
+  echo "   Device $DEVICE_PATH already formatted"
+else
+  echo "   Formatting $DEVICE_PATH"
+  mkfs.ext4 -m 0 -F -E lazy_itable_init=0,lazy_journal_init=0,discard $DEVICE_PATH
+  echo UUID=$(blkid -s UUID -o value $DEVICE_PATH) /mnt/disks/$MNT_DIR ext4 discard,defaults,nofail 0 2 | tee -a /etc/fstab
+  cat /etc/fstab
+  df -Th
+fi
+
+echo "   Mounting to $MNT_DIR"
+mkdir -p /mnt/disks/$MNT_DIR
+mount -o discard,defaults /dev/sdb /mnt/disks/$MNT_DIR
+chmod a+w /mnt/disks/$MNT_DIR
+
+# ----- Install Docker
+echo "=> Installing Docker"
+apt-get update
+apt-get install --yes apt-transport-https ca-certificates gnupg-agent software-properties-common
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
+add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+apt-get install --yes docker-ce docker-ce-cli containerd.io
+
+# ----- Configure system limits
+echo "=> Configuring system limits"
+swapoff -a
+sysctl -w vm.swappiness=1
+sysctl -w fs.file-max=262144
+sysctl -w vm.max_map_count=262144
+cat >> /etc/security/limits.conf <<EOF
+* - memlock unlimited
+* - nofile  500000
+* - nproc   unlimited
+EOF
+
+# ----- Create configuration for Nginx
+echo "=> Creating configuration for Nginx"
+mkdir -p /etc/nginx/
+cat > /etc/nginx/nginx.conf <<-'EOF'
+${nginx_config}
+EOF
+
+# ----- Setup Certbot and extract Letsencrypt archive
+echo "=> Installing certificates"
+snap install --classic certbot
+ln -s /snap/bin/certbot /usr/bin/certbot
+gsutil cp gs://${bucket_name}/assets/letsencrypt.tar.gz /tmp/letsencrypt.tar.gz
+tar -zxf /tmp/letsencrypt.tar.gz -C /
+certbot renew --standalone
+
+echo "=> Starting Docker containers"
+
+# ----- Create Docker network for services
+docker network create faktory
+
+# ----- Run the Faktory container
+docker run --name faktory \
+  --volume /mnt/disks/data/:/var/lib/faktory \
+  --env FAKTORY_PASSWORD=${faktory_password} \
+  --network faktory \
+  --restart always \
+  --detach \
+  contribsys/faktory \
+  /faktory -b :7419 -w :7420 -e production
+
+# ----- Run the Nginx container
+docker run --name nginx \
+  --volume /etc/nginx/:/etc/nginx/ \
+  --volume /etc/letsencrypt/:/etc/letsencrypt/ \
+  --network faktory \
+  --publish 443:443 \
+  --publish 7491:7491 \
+  --ulimit nofile=65535:65535 \
+  --restart always \
+  --detach \
+  nginx

--- a/infrastructure/faktory/terraform/variables.tf
+++ b/infrastructure/faktory/terraform/variables.tf
@@ -1,0 +1,36 @@
+variable "instance_type" {
+  description = "The instance type"
+  default     = "e2-micro"
+}
+
+variable "instance_image" {
+  description = "The instance OS image"
+  default     = "ubuntu-1804-lts"
+}
+
+variable "instance_region" {
+  description = "The GCP region where to create the instance"
+  default     = "europe-west1"
+}
+
+variable "assets_bucket_name" {
+  description = "The bucket name for Terraform state and other assets"
+  default     = "terraform-cesko-digital-faktory"
+}
+
+variable "aws_zone_id" {
+  description = "The ID of the AWS Route 53 hosted zone"
+  default     = "Z1GEPNR58RFJ4N"
+}
+
+variable "faktory_password" {
+  type        = string
+  description = "Password for accessing Faktory"
+  nullable    = false
+  sensitive   = true
+
+  validation {
+    condition     = length(var.faktory_password) >= 30
+    error_message = "The password must be at least 30 character long."
+  }
+}


### PR DESCRIPTION
Tento patch přidává konfiguraci pro Terraform, která spustí instalaci [`contribsys/faktory`](https://github.com/contribsys/faktory), s Nginx jako reverzní proxy, poskytující TLS přístup.

Konfigurace je ve složce `terraform`, složka `demo` obsahuje konfigurace a skripty pro lokální spuštění a ladění.

Instalace a konfigurace služeb je provedena skrze _startup script_ v `terraform/scripts/startup.sh.tmpl`.